### PR TITLE
Support future "notify" property

### DIFF
--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,6 +1,6 @@
 class ChangesController < ApplicationController
   def index
-    @changes = JSON.parse(RestClient.get('https://supercharge.info/service/supercharge/allChanges'))
+    @changes = JSON.parse(RestClient.get('https://supercharge.info/service/supercharge/allChanges')).select{|d| d['notify'] != false }
     @changes = @changes.select{|d| d['country'].downcase == params[:country].downcase } if params[:country].present?
     @changes = @changes.select{|d| d['region'].downcase == params[:region].downcase } if params[:region].present?
 


### PR DESCRIPTION
I'll migrate the changes to include the notify property to test.supercharge.info soon, but it appears to support both no property (current) and a true/false future value.